### PR TITLE
Convert the Technical Charter to rst

### DIFF
--- a/Governance/TungstenFabricProjectTechnicalCharter.rst
+++ b/Governance/TungstenFabricProjectTechnicalCharter.rst
@@ -1,0 +1,311 @@
+Technical Charter (the "Charter")
+=================================
+
+for
+===
+
+Tungsten Fabric Project a Series of LF Projects, LLC
+====================================================
+
+Adopted March 13, 2018
+
+This charter (the “Charter”) sets forth the responsibilities and
+procedures for technical contribution to, and oversight of, the Tungsten
+Fabric Project, which has been established as Tungsten Fabric Project a
+Series of LF Projects, LLC (the “Project”). LF Projects, LLC (“LF
+Projects”) is a Delaware series limited liability company. All
+Contributors to the Project must comply with the terms of this Charter.
+
+1) **Mission and Scope of the Project**
+
+   a. The Tungsten Fabric Project is an open source project that is
+      built using standards-based protocols and provides all the
+      necessary components for network virtualization and network
+      security. The components of the Project include: an SDN
+      controller, virtual router, analytics engine, published northbound
+      APIs, hardware integration features, cloud orchestration software
+      and an extensive REST API.
+
+   b. The mission of the Project is to facilitate the development,
+      evolution and adoption of the Tungsten Fabric Project codebase to
+      enable a comprehensive network and security fabric that
+      encompasses various open source ecosystems, including virtual
+      machine-based public and private clouds, container-based clouds
+      and ecosystems and other computational platforms. The community’s
+      goal is to maintain and improve the production-ready and scalable
+      nature of the Project while accelerating development and
+      attracting additional developers and users to the platform.
+
+   c. The scope of the Project includes development of the Tungsten
+      Fabric code base under an OSI-approved open source license
+      supporting the mission, including documentation, testing,
+      integration and the creation of other artifacts that aid the
+      development, deployment, operation or adoption of the Project.
+
+2) **Technical Steering Committee**
+
+   a. The TSC is responsible for:
+
+      i.    Setting high level architecture goals and coordinating
+            overall project architecture and technical direction
+
+      ii.   Selecting technology stack, software features and supported
+            hardware including
+
+      iii.  approving project or system proposals (including, but not
+            limited to, incubation, deprecation, and changes to a
+            sub-project’s scope);
+
+      iv.   organizing sub-projects and removing sub-projects;
+
+      v.    Developing Project use cases;
+
+      vi.   Defining and monitoring Project technical processes and
+            interfaces with third party code and external projects
+            including creating sub-committees or working groups to focus
+            on cross-project technical issues and requirements;
+
+      vii.  Overseeing the Infrastructure Working Group other TSC
+            working groups;
+
+      viii. Appointing representatives to work with other open source or
+            open standards communities;
+
+      ix.   Establishing community norms, workflows, issuing releases,
+            and security issue reporting policies;
+
+      x.    Approving and implementing policies and processes for
+            contributing (to be published in the CONTRIBUTING file) and
+            coordinating with other project committees to resolve
+            matters or concerns that may arise as set forth in Section 7
+            of this Charter;
+
+      xi.   Engaging in discussions, seeking consensus, and where
+            necessary, voting on technical matters relating to the code
+            base that affect multiple projects;
+
+      xii.  Setting target dates for software development and testing;
+
+      xiii. Coordinating any marketing, events, or communications
+            regarding the Project with the Manager of LF Projects and
+            the Marketing Advisory Council of the LF Networking Fund of
+            The Linux Foundation (“LFN”);
+
+      xiv.  Establishing a vetting process for maintaining security and
+            integrity of new and/or changed code base and documentation,
+            including vetting for malicious code and spyware; and
+
+      xv.   Establishing a security issue reporting policy and
+            resolution procedure.
+
+   b. The TSC voting members are initially selected from the Project’s
+      Committers and Community volunteers. The TSC voting members, TSC
+      election process and TSC defined processes and procedures will be
+      documented in the TSC section of the community documentation
+      repository. TSC will initially have 11 voting members, but may
+      modify the number of voting members by two-thirds vote of all TSC
+      members.
+
+   c. Any meetings of the Technical Steering Committee are intended to
+      be open to the public, and can be conducted electronically, via
+      teleconference, or in person.
+
+   d. TSC projects generally will involve Contributors and Committers.
+      The TSC may adopt or modify roles so long as the roles are
+      documented in the TSC section of the community documentation
+      repository. Unless otherwise documented:
+
+      i.   Contributors include anyone in the technical community that
+             contributes code, documentation, or other technical
+             artifacts to the Project;
+
+      ii.  Committers are Contributors who have earned the ability to
+             modify (“commit”) source code, documentation or other
+             technical artifacts in a project’s repository;
+
+      iii. The primary distinguishing characteristic of Committers is
+             a demonstrated history of performing code reviews in the
+             project code review system. References to quantity and/or
+             quality of code reviews (of other Contributors’ code, not
+             the Committer’s own code) should be given predominant
+             weight when voting on the addition or removal of a
+             Committer;
+
+      iv.   A Contributor may become a Committer by a majority approval
+             of the existing Committers. A Committer may be removed by a
+             majority approval of the other existing Committers; and
+
+      v.    A Committer may be elected by other sub-project Committers
+             to serve as a Project Technical Lead (PTL) and provide
+             direction for a sub-project. The TSC may cast a tiebreaking
+             vote or appoint a PTL in the absence of a majority
+             agreement of the Committers.
+
+   e. Participation in the Project through becoming a Contributor and
+      Committer is open to anyone so long as they abide by the terms of
+      this Charter.
+
+   f. The TSC may (1) establish workflow procedures for the submission,
+      approval, and closure/archiving of projects, (2) set requirements
+      for the promotion of Contributors to Committer status, as
+      applicable, and (3) amend, adjust, refine and/or eliminate the
+      roles of Contributors, and Committers, and create new roles, and
+      publicly document any TSC roles, as it sees fit.
+
+   g. The TSC will elect a TSC Chair, annually, who will preside over
+      meetings of the TSC and will serve until their resignation or
+      replacement by the TSC. The TSC Chair, or any other TSC member so
+      designated by the TSC, will serve as the primary communication
+      contact between the Project and LFN.
+
+3) **TSC Voting**
+
+   a. While the Project aims to operate as a consensus based community,
+      if any TSC decision requires a vote to move the Project forward,
+      the voting members of the TSC will vote on a one vote per voting
+      member basis.
+
+   b. TSC votes must be conducted electronically, even if initiated
+      verbally at a meeting, and, except as provided in Sections 2.b.,
+      7.c. and 8.a., decisions will require the majority of all voting
+      members of the TSC.
+
+   c. TSC will define and document an appropriate conflict resolution
+      mechanism, subject to approval by the Series Manager. This
+      mechanism will be used in the event a vote cannot be resolved by
+      the TSC.
+
+4) **Compliance with Policies**
+
+   a. This Charter is subject to the Series Agreement for the Project
+      and the Operating Agreement of LF Projects. Contributors will
+      comply with the policies of LF Projects as may be adopted and
+      amended by LF Projects, including, without limitation the policies
+      listed at https://lfprojects.org/policies/.
+
+   b. The TSC may adopt a code of conduct (“CoC”) for the Project, which
+      is subject to approval by the Series Manager. Contributors to the
+      Project will comply with the CoC or, in the event that a
+      Project-specific CoC has not been approved, the LF Projects Code
+      of Conduct listed at https://lfprojects.org/policies/.
+
+   c. When amending or adopting any policy applicable to the Project, LF
+      Projects will publish such policy, as to be amended or adopted, on
+      its web site at least 30 days prior to such policy taking effect;
+      provided, however, that in the case of any amendment of the
+      Trademark Policy or Terms of Use of LF Projects, any such
+      amendment is effective upon publication on LF Project’s web site.
+
+   d. All participants must allow open participation from any individual
+      or organization meeting the requirements for contributing under
+      this Charter and any policies adopted for all participants by the
+      TSC, regardless of competitive interests. Put another way, the
+      Project community must not seek to exclude any participant based
+      on any criteria, requirement, or reason other than those that are
+      reasonable and applied on a non- discriminatory basis to all
+      participants. Contribution requirements will be set based on
+      reasonable criteria and applied on a non-discriminatory basis to
+      all participants in the Project community.
+
+   e. The Project will operate in a transparent, open, collaborative,
+      and ethical manner at all times. The output of all Project
+      discussions, proposals, timelines, decisions, and status should be
+      made open and easily visible to all. Any potential violations of
+      this requirement should be reported immediately to the LF Projects
+      Manager.
+
+5) **Community Assets**
+
+   a. LF Projects will hold title to all trade or service marks used by
+      the Project (“Project Trademarks”), whether based on common law or
+      registered rights. Project Trademarks will be transferred and
+      assigned to LF Projects to hold on behalf of the Project. Any use
+      of any Project Trademarks by participants in the Project will be
+      in accordance with the license from LF Projects and inure to the
+      benefit of LF Projects.
+
+   b. The Project will, as permitted and in accordance with such license
+      from LF Projects, develop and own all Project GitHub and social
+      media accounts, and domain name registrations created by the
+      Project community.
+
+   c. Under no circumstances will LF Projects be expected or required to
+      undertake any action on behalf of the Project that is inconsistent
+      with the tax-exempt status or purpose, as applicable, of LFP, Inc.
+      or LF Projects, LLC.
+
+6) **General Rules and Operations.**
+
+   a. The Project will:
+
+      i.  engage in the work of the project in a professional manner
+            consistent with maintaining a cohesive community, while also
+            maintaining the goodwill and esteem of LF Projects, LFP,
+            Inc. and other partner organizations in the open source
+            software community; and
+
+      ii. respect the rights of all trademark owners, including any
+            branding and trademark usage guidelines.
+
+7) **Intellectual Property Policy**
+
+   a. Participants acknowledge that the copyright in all new
+      contributions will be retained by the copyright holder as
+      independent works of authorship and that no contributor or
+      copyright holder will be required to assign copyrights to the
+      Project.
+
+   b. Except as described in Section 7.c., all code contributions to the
+      Project are subject to the following:
+
+      i. All new inbound code contributions to the Project must be
+             made using the Apache License, Version 2.0 (available here:
+             https://www.apache.org/licenses/LICENSE-2.0) (the “Project
+             License”).
+
+      ii.  All new inbound code contributions must:
+
+             1. be made pursuant to a duly executed Corporate
+                Contributor License Agreement or, in the case of
+                self-employed contributors, a duly executed Individual
+                Contributor License Agreement (forms of which are
+                available on the Project’s web site); and
+
+             2. be accompanied by a Developer Certificate of Origin
+                (http://developercertificate.org) sign-off in the source
+                code system that is submitted through a TSC-approved
+                contribution process which will bind the authorized
+                contributor and, if not self-employed, their employer to
+                the applicable license;
+
+      iii.   All outbound code will be made available under the Project
+             License.
+
+      iv.  Documentation will be received and made available by the
+             Project under the Creative Commons Attribution 4.0
+             International License (available at
+             http://creativecommons.org/licenses/by/4.0/).
+
+      v. The Project may seek to integrate and contribute back to
+             other open source projects (“Upstream Projects”). In such
+             cases, the Project will conform to all license requirements
+             of the Upstream Projects, including dependencies, leveraged
+             by the Project. Upstream Project code contributions not
+             stored within the Project’s main code repository will
+             comply with the contribution process and license terms for
+             the applicable Upstream Project.
+
+   c. The TSC may approve the use of an alternative license or licenses
+      for inbound or outbound contributions on an exception basis. To
+      request an exception, please describe the contribution, the
+      alternative open source license(s), and the justification for
+      using an alternative open source license for the Project. License
+      exceptions must be approved by a two-thirds vote of the entire
+      TSC. Contributed files should contain license information, such as
+      SPDX short form identifiers, indicating the open source license or
+      licenses pertaining to the file.
+
+8) **Amendments**
+
+   a. This charter may be amended by a two-thirds vote of the entire TSC
+      and is subject to approval by LF Projects.


### PR DESCRIPTION
Converted the Technical Charter from Google Docs to reStructuredtext.

See Issue #9 for full details.

Closes #9.